### PR TITLE
Update indentity

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -45,7 +45,7 @@
   "skip_source_output_uploading": false,
   "need_preview_pull_request": true,
   "contribution_branch_mappings": {
-    "master-sxs": "master"
+    "live-sxs": "live"
   },
   "dependent_repositories": [
     {

--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -6,7 +6,7 @@
       "build_source_folder": "aspnet",
       "build_output_subfolder": "aspnet",
       "locale": "pt-br",
-      "open_to_public_contributors": false,
+      "open_to_public_contributors": true,
       "type_mapping": {
         "Conceptual": "Content",
         "ManagedReference": "Content",
@@ -39,6 +39,8 @@
     "live",
     "master"
   ],
+  "git_repository_url_open_to_public_contributors": "https://github.com/aspnet/Docs.pt-br",
+  "git_repository_branch_open_to_public_contributors": "live",
   "continue_with_document_error": true,
   "skip_source_output_uploading": false,
   "need_preview_pull_request": true,

--- a/aspnet/breadcrumb/toc.yml
+++ b/aspnet/breadcrumb/toc.yml
@@ -1,4 +1,4 @@
-- name: Documentos
+- name: Docs
   tocHref: /
   topicHref: /
   items:

--- a/aspnetcore/security/authentication/identity.md
+++ b/aspnetcore/security/authentication/identity.md
@@ -17,7 +17,7 @@ ms.translationtype: MT
 ms.contentlocale: pt-BR
 ms.lasthandoff: 09/22/2017
 ---
-# <a name="introduction-to-identity-on-aspnet-core"></a>Introdução à identidade no núcleo do ASP.NET
+# <a name="introduction-to-identity-on-aspnet-core"></a>Introdução à identidade no ASP.NET Core
 
 Por [Pranav Rastogi](https://github.com/rustd), [Rick Anderson](https://twitter.com/RickAndMSFT), [Tom Dykstra](https://github.com/tdykstra), Jon Galloway [Erik Reitan](https://github.com/Erikre), e [Steve Smith](https://ardalis.com/)
 


### PR DESCRIPTION
Change of the term "núcleo" to  "core" as the English nomenclature is most used, then no translation needs.