### PR TITLE
Update custom-formatters

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -45,7 +45,7 @@
   "skip_source_output_uploading": false,
   "need_preview_pull_request": true,
   "contribution_branch_mappings": {
-    "master-sxs": "master"
+    "live-sxs": "live"
   },
   "dependent_repositories": [
     {

--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -6,7 +6,7 @@
       "build_source_folder": "aspnet",
       "build_output_subfolder": "aspnet",
       "locale": "pt-br",
-      "open_to_public_contributors": false,
+      "open_to_public_contributors": true,
       "type_mapping": {
         "Conceptual": "Content",
         "ManagedReference": "Content",
@@ -39,6 +39,8 @@
     "live",
     "master"
   ],
+  "git_repository_url_open_to_public_contributors": "https://github.com/aspnet/Docs.pt-br",
+  "git_repository_branch_open_to_public_contributors": "live",
   "continue_with_document_error": true,
   "skip_source_output_uploading": false,
   "need_preview_pull_request": true,

--- a/aspnet/breadcrumb/toc.yml
+++ b/aspnet/breadcrumb/toc.yml
@@ -1,4 +1,4 @@
-- name: Documentos
+- name: Docs
   tocHref: /
   topicHref: /
   items:

--- a/aspnetcore/mvc/advanced/custom-formatters.md
+++ b/aspnetcore/mvc/advanced/custom-formatters.md
@@ -17,7 +17,7 @@ ms.translationtype: MT
 ms.contentlocale: pt-BR
 ms.lasthandoff: 09/22/2017
 ---
-# <a name="custom-formatters-in-aspnet-core-mvc-web-apis"></a>APIs da web personalizados formatadores no ASP.NET MVC de núcleo
+# <a name="custom-formatters-in-aspnet-core-mvc-web-apis"></a>APIs da web personalizados formatadores no ASP.NET MVC Core
 
 Por [Tom Dykstra](https://github.com/tdykstra)
 


### PR DESCRIPTION
Translation of the term  "Núcleo" is not required

The term "ASP.NET Core " is most used, its translation can confuse.

Issue #18 