### PR TITLE
Fix ASP.NET Core title translation

### DIFF
--- a/aspnetcore/security/authentication/identity.md
+++ b/aspnetcore/security/authentication/identity.md
@@ -1,5 +1,5 @@
 ---
-title: "Introdução à identidade no núcleo do ASP.NET"
+title: "Introdução à identidade do ASP.NET Core"
 author: rick-anderson
 description: "Use identidade com um aplicativo do ASP.NET Core. Inclui a configuração de senha (RequireDigit, RequiredLength, RequiredUniqueChars e muito mais)."
 manager: wpickett


### PR DESCRIPTION
"ASP.NET Core" should not be translated.