### PR TITLE
Corrigindo nome da variável.

### DIFF
--- a/aspnetcore/mvc/advanced/app-parts.md
+++ b/aspnetcore/mvc/advanced/app-parts.md
@@ -50,7 +50,7 @@ services.AddMvc()
 
         if (dependentLibrary != null)
         {
-           p.ApplicationParts.Remove(dependentLibrary);
+           apm.ApplicationParts.Remove(dependentLibrary);
         }
     })
 ```


### PR DESCRIPTION
Corrigindo a linha 53 onde estava a.ApplicationParts.Remove(dependentLibrary). Ao tentar copiar o exemplo o mesmo dava erro pois a variável correta se chamava apm.