### PR TITLE
Update GoogleOptions link in google-logins.md

### DIFF
--- a/aspnetcore/security/authentication/social/google-logins.md
+++ b/aspnetcore/security/authentication/social/google-logins.md
@@ -56,7 +56,7 @@ Adicionar o serviço do Google para `Startup.ConfigureServices`.
 
 [!INCLUDE[](includes/chain-auth-providers.md)]
 
-Consulte a [GoogleOptions](/dotnet/api/microsoft.aspnetcore.builder.googleoptions) referência da API para obter mais informações sobre opções de configuração com suporte pela autenticação do Google. Isso pode ser usado para solicitar informações diferentes sobre o usuário.
+Consulte a [GoogleOptions](/dotnet/api/microsoft.aspnetcore.authentication.google.googleoptions) referência da API para obter mais informações sobre opções de configuração com suporte pela autenticação do Google. Isso pode ser usado para solicitar informações diferentes sobre o usuário.
 
 ## <a name="change-the-default-callback-uri"></a>Alterar o retorno de chamada padrão URI
 


### PR DESCRIPTION
First link to GoogleOptions Class refers to version 1.0 and 1.1 DotNet Core, and second link refers to version 2.x. I suggest link both to most recent version.