### PR TITLE
Correção do caractere separador de restrições

### DIFF
--- a/aspnetcore/fundamentals/routing.md
+++ b/aspnetcore/fundamentals/routing.md
@@ -630,7 +630,7 @@ A tabela a seguir demonstra restrições de rota de exemplo e seu comportamento 
 | `regex(expression)` | `{ssn:regex(^\\d{{3}}-\\d{{2}}-\\d{{4}}$)}` | `123-45-6789` | A cadeia de caracteres deve corresponder à expressão regular (veja as dicas sobre como definir uma expressão regular) |
 | `required` | `{name:required}` | `Rick` | Usado para impor que um valor não parâmetro está presente durante a geração de URL |
 
-Várias restrições delimitadas por vírgula podem ser aplicadas a um único parâmetro. Por exemplo, a restrição a seguir restringe um parâmetro para um valor inteiro de 1 ou maior:
+Várias restrições delimitadas por dois pontos podem ser aplicadas a um único parâmetro. Por exemplo, a restrição a seguir restringe um parâmetro para um valor inteiro de 1 ou maior:
 
 ```csharp
 [Route("users/{id:int:min(1)}")]

--- a/aspnetcore/fundamentals/routing.md
+++ b/aspnetcore/fundamentals/routing.md
@@ -630,7 +630,7 @@ A tabela a seguir demonstra restrições de rota de exemplo e seu comportamento 
 | `regex(expression)` | `{ssn:regex(^\\d{{3}}-\\d{{2}}-\\d{{4}}$)}` | `123-45-6789` | A cadeia de caracteres deve corresponder à expressão regular (veja as dicas sobre como definir uma expressão regular) |
 | `required` | `{name:required}` | `Rick` | Usado para impor que um valor não parâmetro está presente durante a geração de URL |
 
-Várias restrições delimitadas por dois pontos podem ser aplicadas a um único parâmetro. Por exemplo, a restrição a seguir restringe um parâmetro para um valor inteiro de 1 ou maior:
+Várias restrições delimitadas por dois-pontos podem ser aplicadas a um único parâmetro. Por exemplo, a restrição a seguir restringe um parâmetro para um valor inteiro de 1 ou maior:
 
 ```csharp
 [Route("users/{id:int:min(1)}")]


### PR DESCRIPTION
O caractere que permite encadear múltiplas restrições em um parâmetro é o dois pontos e não a vírgula, como constava no texto e inclusive conflitava com o exemplo que é dado logo em seguida:

```csharp
[Route("users/{id:int:min(1)}")]
public User GetUserById(int id) { }
```